### PR TITLE
Fix handling spaces in path to Breeze Daemon

### DIFF
--- a/Breeze.UI/main.ts
+++ b/Breeze.UI/main.ts
@@ -12,8 +12,10 @@ const os = require('os');
 var apiProcess;
 
 let serve;
+let debug;
 const args = process.argv.slice(1);
 serve = args.some(val => val === "--serve");
+debug = args.some(val => val === "--debug");
 
 if (serve) {
   require('electron-reload')(__dirname, {
@@ -44,7 +46,7 @@ function createWindow() {
     slashes: true
   }));
 
-  if (serve) {
+  if (serve || debug) {
     mainWindow.webContents.openDevTools();
   }
 
@@ -115,14 +117,19 @@ function startApi() {
       apipath = path.join(__dirname, '.\\assets\\daemon\\Breeze.Daemon.exe');
   }
 
+  //Handle spaces in paths
+  apipath = apipath.replace(/ /g, '\\ ');
+
   apiProcess = exec(apipath + ' light -testnet', {
       detached: true
-  });
-
-  apiProcess.stdout.on('data', (data) => {
-      writeLog(`stdout: ${data}`);
-      if (mainWindow == null) {
-          createWindow();
+  }, (error, stdout, stderr) => {
+      if (error) {
+          writeLogError(`exec error: ${error}`);
+          return;
+      }
+      if (debug) {
+        writeLog(`stdout: ${stdout}`);
+        writeLog(`stderr: ${stderr}`);
       }
   });
 }
@@ -157,5 +164,9 @@ if (os.platform() === 'win32') {
 };
 
 function writeLog(msg) {
-    console.log(msg);
+  console.log(msg);
+};
+
+function writeLogError(msg) {
+  console.error(msg);
 };

--- a/Breeze.UI/main.ts
+++ b/Breeze.UI/main.ts
@@ -12,10 +12,8 @@ const os = require('os');
 var apiProcess;
 
 let serve;
-let debug;
 const args = process.argv.slice(1);
 serve = args.some(val => val === "--serve");
-debug = args.some(val => val === "--debug");
 
 if (serve) {
   require('electron-reload')(__dirname, {
@@ -46,7 +44,7 @@ function createWindow() {
     slashes: true
   }));
 
-  if (serve || debug) {
+  if (serve) {
     mainWindow.webContents.openDevTools();
   }
 
@@ -127,7 +125,7 @@ function startApi() {
           writeLogError(`exec error: ${error}`);
           return;
       }
-      if (debug) {
+      if (serve) {
         writeLog(`stdout: ${stdout}`);
         writeLog(`stderr: ${stderr}`);
       }


### PR DESCRIPTION
Currently, if you put Breeze in a path that includes spaces, it fails to launch Breeze Daemon on windows.

I have added the gsub to replaces spaces with escaped spaces. I also fixed the logging, as the `stdout.on` style didn't work for me to debug anything. I added the lambda into the exec function directly, and that outputs data for me.

Also added the debug flag, so we don't spam logs or anything when not needed, but can be activated for debugging.