### PR TITLE
Use same System.ValueTuple as full node project

### DIFF
--- a/Breeze/src/Breeze.Wallet/Breeze.Wallet.csproj
+++ b/Breeze/src/Breeze.Wallet/Breeze.Wallet.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="1.0.3" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="1.0.1" />    
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0-preview1-25305-02" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove a warning of uncompatible versions between Stratis Node and Breeze