### PR TITLE
Fix @angular/cli install instruction

### DIFF
--- a/Breeze.UI/README.md
+++ b/Breeze.UI/README.md
@@ -27,7 +27,7 @@ If you want to generate Angular components with Angular-cli , you **MUST** insta
 Please follow [Angular-cli documentation](https://github.com/angular/angular-cli) if you had installed a previous version of `angular-cli`.
 
 ``` bash
-npm install -g @angular/cli
+sudo npm install -g @angular/cli
 ```
 
 ## To build for development


### PR DESCRIPTION
Installing npm packages in global context (-g flag) requires root privileges, as install directory is in /usr/local/lib/node_modules/[module_name]