### PR TITLE
build caches and portable package names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ env:
   - arch=x64
   - configuration=Release  
   - os_platform=linux
+
+cache:
+  directories:
+  - node_modules
   
 # Work around NuGet issue #2163
 # https://github.com/NuGet/Home/issues/2163

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ matrix:
     dist: trusty
     sudo: required
     dotnet: 2.0.0
-    env: os_identifier=ubuntu.14.04
   - os: osx # OSX 10.12
     osx_image: xcode9
-    env: os_identifier=osx.10.12
     before_install:
     - brew update
     - curl https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 
 cache:
   directories:
-  - node_modules
+  - Breeze.UI/node_modules
   
 # Work around NuGet issue #2163
 # https://github.com/NuGet/Home/issues/2163

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ env:
 
 cache:
   directories:
-  - Breeze.UI/node_modules
+  - ${TRAVIS_BUILD_DIR}/Breeze.UI/node_modules
+  - $HOME/.nuget/packages  
+  - /usr/share/dotnet/sdk/2.0.0/
   
 # Work around NuGet issue #2163
 # https://github.com/NuGet/Home/issues/2163

--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -12,6 +12,13 @@
       "icon": "dist/assets/images/breeze-logo",
       "target": ["nsis"]
   },
+  "linux": {
+      "target": [
+        "deb",
+        "tar.gz"		
+	   ],
+	  "category": "Utility"
+  }
   "nsis": {
     "oneClick": false,
 	"perMachine": true,

--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -18,7 +18,7 @@
         "tar.gz"		
 	   ],
 	  "category": "Utility"
-  }
+  },
   "nsis": {
     "oneClick": false,
 	"perMachine": true,

--- a/README.md
+++ b/README.md
@@ -52,17 +52,14 @@ If you want the :sparkles: latest :sparkles: (unstable :bomb:) version of the Br
 
 |    | x86 Release | x64 Release | Notes |
 |:---|----------------:|------------------:|------------------:|
-|**Windows 7**| [download][7] | [download][8] | continuous build - up to date with commits |
-|**Windows 10**| [download][9] | [download][10] | continuous build - up to date with commits | 
-|**Ubuntu 14.04**| - | [download][11] | continuous build - up to date with commits |
-|**OS X 10.12**| - | [download][12] |  continuous build - up to date with commits |
+|**Windows**| [download][7] | [download][8] | Windows 7 and Windows 10 |
+|**Linux**| - | [download][9] | All Linux flavors |
+|**OS X**| - | [download][10] |  From OSX 10.12 |
 
 
-[7]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win7-x86.exe
-[8]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win7-x64.exe
-[9]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win10-x86.exe
-[10]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win10-x64.exe
-[11]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/breeze-ubuntu.14.04-x64-Release.zip
-[12]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/breeze-osx.10.12-x64-Release.zip
+[7]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win-x86.exe
+[8]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/Breeze.Wallet.v0.3.0.setup.win-x64.exe
+[9]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/breeze-linux-x64.zip
+[10]: https://github.com/stratisproject/Breeze/releases/download/cd-unstable/breeze-osx-x64.zip
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,8 @@ environment:
 
 # build cache to preserve files/folders between builds
 cache:
-  - $env:APPVEYOR_BUILD_FOLDER/Breeze.UI/node_modules
-  - '%USERPROFILE%\.nuget\packages
+  - '%APPVEYOR_BUILD_FOLDER%/Breeze.UI/node_modules'
+  - '%USERPROFILE%\.nuget\packages'
   
 init:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ environment:
 
 # build cache to preserve files/folders between builds
 cache:
-  - node_modules
+  - Breeze.UI/node_modules
   
 init:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ environment:
 
 # build cache to preserve files/folders between builds
 cache:
-  - '%APPVEYOR_BUILD_FOLDER%/Breeze.UI/node_modules'
+  - '%APPVEYOR_BUILD_FOLDER%\Breeze.UI\node_modules'
   - '%USERPROFILE%\.nuget\packages'
   
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ branches:
 image: Visual Studio 2017
 clone_folder: c:\projects\breeze
 configuration:
- # - Debug
   - Release
 
 build:
@@ -43,9 +42,6 @@ cache:
 init:
 - ps: |
       $env:log_prefix = "[$env:win_runtime][$env:configuration]"
-      $env:node_output_name = "Breeze-$env:plat-$env:arch"
-      $env:app_output_name = "breeze-$env:win_runtime"
-      $env:app_output_zip_name = "breeze-$env:win_runtime-$env:configuration.zip"
       if ($env:APPVEYOR_REPO_TAG -eq "false") { $env:APPVEYOR_REPO_TAG_NAME = "cd-unstable" }
 
 install:
@@ -81,9 +77,6 @@ before_build:
       Write-Host "Windows runtime: $env:win_runtime" -foregroundcolor "magenta"
       Write-Host "Build directory: $env:APPVEYOR_BUILD_FOLDER" -foregroundcolor "magenta"
       Write-Host "Configuration: $env:configuration" -foregroundcolor "magenta"
-      Write-Host "node.js output name: $env:node_output_name" -foregroundcolor "magenta"
-      Write-Host "App output folder name: $env:app_output_name" -foregroundcolor "magenta"
-      Write-Host "App output zip file name: $env:app_output_zip_name" -foregroundcolor "magenta"
       Write-Host "Branch: $env:APPVEYOR_REPO_BRANCH" -foregroundcolor "magenta"
       Write-Host "Tag is set: $env:APPVEYOR_REPO_TAG" -foregroundcolor "magenta"
       Write-Host "Tag: $env:APPVEYOR_REPO_TAG_NAME" -foregroundcolor "magenta"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,16 +28,10 @@ build:
 
 environment:
   matrix:
-  - win_runtime: win7-x64
+  - win_runtime: win-x64
     arch: x64
     plat: win32
-  - win_runtime: win7-x86
-    arch: ia32
-    plat: win32
-  - win_runtime: win10-x64
-    arch: x64
-    plat: win32
-  - win_runtime: win10-x86
+  - win_runtime: win-x86
     arch: ia32
     plat: win32
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,8 @@ environment:
 
 # build cache to preserve files/folders between builds
 cache:
-  - Breeze.UI/node_modules
+  - $env:APPVEYOR_BUILD_FOLDER/Breeze.UI/node_modules
+  - '%USERPROFILE%\.nuget\packages
   
 init:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,10 @@ environment:
     arch: ia32
     plat: win32
 
+# build cache to preserve files/folders between builds
+cache:
+  - node_modules
+  
 init:
 - ps: |
       $env:log_prefix = "[$env:win_runtime][$env:configuration]"

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ set -o errexit
 
 # define a few variables
 node_output_name="Breeze-$os_platform-$arch"
-app_output_name="breeze-$os_identifier-$arch"
-app_output_zip_name="breeze-$os_identifier-$arch-$configuration.zip"
+app_output_name="breeze-$os-$arch"
+app_output_zip_name="breeze-$os-$arch-$configuration.zip"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]
 then
@@ -17,7 +17,7 @@ fi
 
 echo "current environment variables:"
 echo "OS name:" $TRAVIS_OS_NAME
-echo "OS identifier:" $os_identifier
+echo "OS identifier:" $os
 echo "Platform:" $os_platform
 echo "Build directory:" $TRAVIS_BUILD_DIR
 echo "Node version:" $TRAVIS_NODE_VERSION
@@ -48,7 +48,7 @@ echo $log_prefix FINISHED restoring dotnet and npm packages
 # dotnet publish
 echo $log_prefix running 'dotnet publish'
 cd $TRAVIS_BUILD_DIR/StratisBitcoinFullNode/Stratis.BreezeD
-dotnet publish -c $configuration -r $os_identifier-$arch -v m -o $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME
+dotnet publish -c $configuration -r $os-$arch -v m -o $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME
 
 echo $log_prefix chmoding the Stratis.BreezeD file
 chmod +x $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME/Stratis.BreezeD

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ set -o errexit
 
 # define a few variables
 node_output_name="Breeze-$os_platform-$arch"
-app_output_name="breeze-$os-$arch"
-app_output_zip_name="breeze-$os-$arch-$configuration.zip"
+app_output_name="breeze-$TRAVIS_OS_NAME-$arch"
+app_output_zip_name="breeze-$TRAVIS_OS_NAME-$arch-$configuration.zip"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]
 then
@@ -17,7 +17,7 @@ fi
 
 echo "current environment variables:"
 echo "OS name:" $TRAVIS_OS_NAME
-echo "OS identifier:" $os
+echo "OS:" $TRAVIS_OS_NAME
 echo "Platform:" $os_platform
 echo "Build directory:" $TRAVIS_BUILD_DIR
 echo "Node version:" $TRAVIS_NODE_VERSION
@@ -48,7 +48,7 @@ echo $log_prefix FINISHED restoring dotnet and npm packages
 # dotnet publish
 echo $log_prefix running 'dotnet publish'
 cd $TRAVIS_BUILD_DIR/StratisBitcoinFullNode/Stratis.BreezeD
-dotnet publish -c $configuration -r $os-$arch -v m -o $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME
+dotnet publish -c $configuration -r $TRAVIS_OS_NAME-$arch -v m -o $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME
 
 echo $log_prefix chmoding the Stratis.BreezeD file
 chmod +x $TRAVIS_BUILD_DIR/dotnet_out/$TRAVIS_OS_NAME/Stratis.BreezeD

--- a/build.sh
+++ b/build.sh
@@ -80,5 +80,8 @@ zip -r $TRAVIS_BUILD_DIR/deploy/$app_output_zip_name $app_output_name/*
 #tests
 echo $log_prefix no tests to run
 
+cd $TRAVIS_BUILD_DIR
+ls
+
 echo $log_prefix FINISHED build
 

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -o errexit
 # define a few variables
 node_output_name="Breeze-$os_platform-$arch"
 app_output_name="breeze-$TRAVIS_OS_NAME-$arch"
-app_output_zip_name="breeze-$TRAVIS_OS_NAME-$arch-$configuration.zip"
+app_output_zip_name="breeze-$TRAVIS_OS_NAME-$arch.zip"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]
 then
@@ -17,7 +17,6 @@ fi
 
 echo "current environment variables:"
 echo "OS name:" $TRAVIS_OS_NAME
-echo "OS:" $TRAVIS_OS_NAME
 echo "Platform:" $os_platform
 echo "Build directory:" $TRAVIS_BUILD_DIR
 echo "Node version:" $TRAVIS_NODE_VERSION


### PR DESCRIPTION
Using build caches to speed up the build
Simplifies the names of the output packages to use portable version of dotnet.
