### PR TITLE
Change naming of package files

### DIFF
--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -11,7 +11,7 @@
       "target":[
          "nsis"
       ],
-      "artifactName":"${productName}.v${version}.setup.${os}.${env.arch}.${ext}"
+      "artifactName":"${productName}-v${version}-setup-${os}-${env.arch}.${ext}"
    },
    "linux":{
       "target":[
@@ -21,14 +21,14 @@
       "synopsis":"Breeze Wallet: Stratis' dual-currency full block light wallet with a strong focus on privacy.",
       "category":"Utility",
       "icon":"dist/assets/images/icons",
-      "artifactName":"${productName}_v${version}-${os}_${arch}.${ext}"
+      "artifactName":"${productName}-v${version}-${os}-${arch}.${ext}"
    },
    "mac":{
       "target":[
          "dmg"
       ],
       "category":"public.app-category.productivity",
-      "artifactName":"${productName}_v${version}_${os}${arch}.${ext}"
+      "artifactName":"${productName}-v${version}-${os}-${arch}.${ext}"
    },
    "nsis":{
       "oneClick":false,

--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -11,7 +11,7 @@
       "target":[
          "nsis"
       ],
-      "artifactName":"${productName}.v${version}.setup.${os}.${env.arch}.${ext}"
+      "artifactName":"${productName}_v${version}_${os}${env.arch}_setup.${ext}"
    },
    "linux":{
       "target":[
@@ -21,14 +21,14 @@
       "synopsis":"Breeze Wallet: Stratis' dual-currency full block light wallet with a strong focus on privacy.",
       "category":"Utility",
       "icon":"dist/assets/images/icons",
-      "artifactName":"${productName}.v${version}.setup.${os}.${arch}.${ext}"
+      "artifactName":"${productName}_v${version}-${os}_${arch}.${ext}"
    },
    "mac":{
       "target":[
          "dmg"
       ],
       "category":"public.app-category.productivity",
-      "artifactName":"${productName}.v${version}.setup.${os}.${arch}.${ext}"
+      "artifactName":"${productName}_v${version}_${os}${arch}.${ext}"
    },
    "nsis":{
       "oneClick":false,

--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -11,7 +11,7 @@
       "target":[
          "nsis"
       ],
-      "artifactName":"${productName}_v${version}_${os}${env.arch}_setup.${ext}"
+      "artifactName":"${productName}.v${version}.setup.${os}.${env.arch}.${ext}"
    },
    "linux":{
       "target":[


### PR DESCRIPTION
Easier reading/identifying of package/installation files based on common naming practice.
After this commit, the files will be named:

```bash
windows:           Breeze Wallet_v0.3.0_win64_setup.exe 
linux:             Breeze Wallet_v0.3.0-linux_amd64.deb
mac:               Breeze Wallet_v0.3.0_osx64.dmg
```