### PR TITLE
The advanced-service calls weren't using the correct URL prefix based…

### DIFF
--- a/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
+++ b/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
@@ -21,7 +21,7 @@ export class AdvancedService {
         this.walletName = this.globalService.getWalletName();
 
         navigationService.pageSubject.subscribe(x => 
-            this.urlPrefix = `http://localhost:3722${Page.Bitcoin ? 0 : 1}/api/Wallet/`);
+            this.urlPrefix = `http://localhost:3722${Page.Bitcoin === x ? 0 : 1}/api/Wallet/`);
     }
 
     public getExtPubKey(): Observable<string> {

--- a/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
+++ b/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
@@ -20,12 +20,12 @@ export class AdvancedService {
     constructor(private httpClient: HttpClient, private globalService: GlobalService, navigationService: NavigationService) { 
         this.walletName = this.globalService.getWalletName();
 
-        navigationService.pageSubject.subscribe(x => 
-            this.urlPrefix = `http://localhost:3722${Page.Bitcoin === x ? 0 : 1}/api/Wallet/`);
+        navigationService.pageSubject.subscribe(x => this.urlPrefix = `http://localhost:3722${x}/api/Wallet/`);
     }
 
     public getExtPubKey(): Observable<string> {
         const url = `${this.urlPrefix}extpubkey?WalletName=${this.walletName}&AccountName=${this.accountName}`;
+        console.log(url);
         return this.httpClient.get(url).map(x => x.toString());
     }
 

--- a/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
+++ b/Breeze.UI/src/app/wallet/advanced/advanced.service.ts
@@ -25,7 +25,6 @@ export class AdvancedService {
 
     public getExtPubKey(): Observable<string> {
         const url = `${this.urlPrefix}extpubkey?WalletName=${this.walletName}&AccountName=${this.accountName}`;
-        console.log(url);
         return this.httpClient.get(url).map(x => x.toString());
     }
 


### PR DESCRIPTION
… on the selected coin - they now do.  