### PR TITLE
Added blank passphrase so wallet can be created

### DIFF
--- a/Breeze.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
+++ b/Breeze.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
@@ -32,7 +32,8 @@ export class ConfirmMnemonicComponent implements OnInit {
       this.newWallet = new WalletCreation(
         params["name"],
         params["mnemonic"],
-        params["password"]
+        params["password"],
+        params["passphrase"]
       )
     });
   }

--- a/Breeze.UI/src/app/shared/classes/wallet-creation.ts
+++ b/Breeze.UI/src/app/shared/classes/wallet-creation.ts
@@ -5,10 +5,12 @@ export class WalletCreation {
     this.mnemonic = mnemonic;
     this.password = password;
     this.folderPath = folderPath;
+    this.passphrase = "";
   }
 
   name: string;
   mnemonic: string;
   password: string;
   folderPath?: string;
+  passphrase: string;
 }


### PR DESCRIPTION
Found that passphrase is a required field in the API docs, but it can be a blank string. To get past an error creating a new wallet when I spun up the app locally I added this code.